### PR TITLE
use stderr for errors and warnings

### DIFF
--- a/src/atac/system_control_t.cpp
+++ b/src/atac/system_control_t.cpp
@@ -240,7 +240,7 @@ bool atac::system_control_t::iterate()
 
     if (mut.name == "error")
     {
-        cout << "Error, mutation attempts exceeded maximum allowed."
+        cerr << "Error: mutation attempts exceeded maximum allowed."
              << endl;
         return false;
     }

--- a/src/common/codegen/util/lookup_table.cpp
+++ b/src/common/codegen/util/lookup_table.cpp
@@ -70,6 +70,6 @@ std::vector<double> generate_lookup_table(unsigned int n_points,
         max_error = std::max(max_error, min_error);
     }
 
-    std::cout << "lookup table max error: " << max_error << std::endl;
+    std::cerr << "lookup table max error: " << max_error << std::endl;
     return values;
 }

--- a/src/common/graph/ud_graph_t.cpp
+++ b/src/common/graph/ud_graph_t.cpp
@@ -23,7 +23,7 @@ vector<pair<int, int>> make_pairlist(const vector<int> &offsets,
     auto bad = any_of(pairs.begin(), pairs.end(), [](auto p) {
         if (p.first < 0 || p.second < 0)
         {
-            cout << "bad pair: " << p.first << ' ' << p.second << endl;
+            cerr << "bad pair: " << p.first << ' ' << p.second << endl;
             return true;
         }
         return false;
@@ -31,26 +31,26 @@ vector<pair<int, int>> make_pairlist(const vector<int> &offsets,
 
     if (bad)
     {
-        cout << "bad pairlist" << endl;
+        cerr << "bad pairlist" << endl;
 
         bad = any_of(edge_ids.begin(), edge_ids.end(), [&](auto i) {
             if (i < 0 || static_cast<std::size_t>(i) >= offsets.size())
             {
-                cout << i << endl;
+                cerr << i << endl;
                 return true;
             }
             return false;
         });
 
         if (bad)
-            cout << "bad edge ids" << endl;
+            cerr << "bad edge ids" << endl;
 
         bad = any_of(offsets.begin(), offsets.end(), [&](auto i) {
             return i < 0 || static_cast<std::size_t>(i) > edge_ids.size();
         });
 
         if (bad)
-            cout << "bad offsets" << endl;
+            cerr << "bad offsets" << endl;
 
         abort();
     }
@@ -265,4 +265,3 @@ bool graph::ud_graph_t::edges_are_duplicated()
     });
 }
 #endif // SP2_ENABLE_TESTS
-

--- a/src/common/io/file_types/cif.cpp
+++ b/src/common/io/file_types/cif.cpp
@@ -14,7 +14,7 @@ bool io::write_cif(std::string filename, const structure_t &structure)
     ofstream outfile(filename);
     if (!outfile.is_open())
     {
-        cout << "Error opening file. " << info << endl;
+        cerr << "Error opening file. " << info << endl;
         return false;
     }
 
@@ -50,4 +50,3 @@ bool io::write_cif(std::string filename, const structure_t &structure)
 
     return true;
 }
-

--- a/src/common/io/file_types/poscar.cpp
+++ b/src/common/io/file_types/poscar.cpp
@@ -132,12 +132,12 @@ bool io::read_poscar(std::string filename, structure_t &output)
             output.types.push_back(types[type_n]);
         }
     } catch (const std::runtime_error ex) {
-        cout << "Error: " << ex.what()
+        cerr << "Error: " << ex.what()
              << " when reading POSCAR file " << filename << endl;
 
         return false;
     } catch (const std::invalid_argument) {
-        cout << "Error, failed parsing value when reading POSCAR file "
+        cerr << "Error, failed parsing value when reading POSCAR file "
              << filename << endl;
 
         return false;
@@ -151,7 +151,7 @@ bool io::write_poscar(std::string filename, const structure_t &input)
     ofstream outfile(filename);
     if (!outfile)
     {
-        cout << "Failed opening file : " << filename << " for read." << endl;
+        cerr << "Failed opening file : " << filename << " for read." << endl;
         return false;
     }
 

--- a/src/common/io/file_types/xyz.cpp
+++ b/src/common/io/file_types/xyz.cpp
@@ -44,7 +44,7 @@ bool io::read_xyz(std::string filename, std::string &comment_line,
     ifstream infile(filename);
     if (!infile.is_open())
     {
-        cout << "Error opening file. " << info << endl;
+        cerr << "Error opening file. " << info << endl;
         return false;
     }
 
@@ -54,7 +54,7 @@ bool io::read_xyz(std::string filename, std::string &comment_line,
 
     if (current_frame != frame)
     {
-        cout << "Failed to read frame " << frame << ". "
+        cerr << "Failed to read frame " << frame << ". "
              << info << endl;
         return false;
     }
@@ -68,7 +68,7 @@ bool io::read_xyz(std::string filename, std::string &comment_line,
     try {
         num_atoms = stoi(line);
     } catch (std::invalid_argument &e) {
-        cout << "Failed to parse number of atoms \"" <<
+        cerr << "Failed to parse number of atoms \"" <<
              line << "\". " << info << endl;
         return false;
     }
@@ -97,7 +97,7 @@ bool io::read_xyz(std::string filename, std::string &comment_line,
 
     if (num_atoms != 0)
     {
-        cout << "Error, read less than specified number of atoms. "
+        cerr << "Error, read less than specified number of atoms. "
              << info << endl;
         return false;
     }
@@ -113,7 +113,7 @@ bool io::write_xyz(std::string filename, const std::string &comment_line,
 
     if (types.size() != positions.size() / 3)
     {
-        cout << "Error, mismatch between atom type and position vector size. "
+        cerr << "Error, mismatch between atom type and position vector size. "
              << info << endl;
         return false;
     }
@@ -126,7 +126,7 @@ bool io::write_xyz(std::string filename, const std::string &comment_line,
 
     if (!outfile.is_open())
     {
-        cout << "Error opening file. " << info << endl;
+        cerr << "Error opening file. " << info << endl;
         return false;
     }
 

--- a/src/common/io/structure.cpp
+++ b/src/common/io/structure.cpp
@@ -73,7 +73,7 @@ bool io::write_structure(std::string filename,
     case file_type::POSCAR:
         return io::write_poscar(filename, input);
     default:
-        cout << "Failed to write structure file \"" + filename + "\""
+        cerr << "Failed to write structure file \"" + filename + "\""
              << " with unknown file type.";
         return false;
     }
@@ -111,7 +111,7 @@ bool io::read_structure(std::string filename,
         else
         {
             if (!comment_line.empty())
-                std::cout << "Warning, non-empty comment failed "
+                std::cerr << "Warning, non-empty comment failed "
                           << "to parse into JSON." << std::endl;
 
             return true;
@@ -126,7 +126,7 @@ bool io::read_structure(std::string filename,
     case file_type::POSCAR:
         return io::read_poscar(filename, output);
     default:
-        cout << "Failed to read structure file \"" + filename + "\""
+        cerr << "Failed to read structure file \"" + filename + "\""
              << " with unknown file type.";
         return false;
     }

--- a/src/common/io/util.cpp
+++ b/src/common/io/util.cpp
@@ -12,7 +12,7 @@ bool io::clear_file(std::string filename)
     ofstream outfile(filename.c_str());
     if (!outfile.is_open())
     {
-        cout << "Error opening " << filename << " in clear_file()!" << endl;
+        cerr << "Error opening " << filename << " in clear_file()!" << endl;
         return false;
     }
     outfile.close();
@@ -65,12 +65,12 @@ bool io::copy_file(std::string source, std::string dest)
 {
     if (dest.empty() || source.empty())
     {
-        cout << "error, source or destination string is empty in copy_file" << endl;
+        cerr << "Error, source or destination string is empty in copy_file" << endl;
         return false;
     }
     if (source[source.size() - 1] == '/' || source[source.size() - 1] == '\\')
     {
-        cout << "error source for copy is a directory: " << source << endl;
+        cerr << "Error, source for copy is a directory: " << source << endl;
         return false;
     }
 
@@ -88,12 +88,12 @@ bool io::copy_file(std::string source, std::string dest)
 
     if (!infile.is_open())
     {
-        cout << "failed opening input file for copy " << source << endl;
+        cerr << "failed opening input file for copy " << source << endl;
         return false;
     }
     else if (!outfile.is_open())
     {
-        cout << "failed opening output file for copy " << dest << endl;
+        cerr << "failed opening output file for copy " << dest << endl;
         return false;
     }
 

--- a/src/common/json/json.cpp
+++ b/src/common/json/json.cpp
@@ -37,7 +37,7 @@ bool io::write_json_file(const Json::Value &root,
 
     if (!io::write_file(filename, content))
     {
-        cout << "Failed to write JSON file \"" << filename << "\"" << endl;
+        cerr << "Failed to write JSON file \"" << filename << "\"" << endl;
         return false;
     }
     return true;
@@ -48,7 +48,7 @@ bool io::read_json(Json::Value &root, const std::string &input)
     Json::Reader reader;
     if (!reader.parse(input, root))
     {
-        cout << "Failed to parse JSON\n"
+        cerr << "Failed to parse JSON\n"
              << reader.getFormattedErrorMessages();
         return false;
     }
@@ -62,7 +62,7 @@ bool io::read_json_file(Json::Value &root, std::string filename)
     string content;
     if (!io::read_file(filename, content))
     {
-        cout << "Failed to open (or empty) JSON file \""
+        cerr << "Failed to open (or empty) JSON file \""
              << filename << "\"" << endl;
         return false;
     }
@@ -77,7 +77,7 @@ bool io::deserialize_field(const Json::Value &val,
 {
     if (!object.deserialize(val[field]))
     {
-        cout << "Error, failed to deserialize (or missing) \"" + field + "\""
+        cerr << "Error, failed to deserialize (or missing) \"" + field + "\""
              << " field in input JSON." << endl;
         return false;
     }

--- a/src/common/json/json.hpp
+++ b/src/common/json/json.hpp
@@ -260,7 +260,7 @@ T deserialize_enum(const Json::Value &value, std::string field_name,
     if (enum_string.empty())
     {
         if (output)
-            std::cout << "Error, failed to deserialize (or missing) "
+            std::cerr << "Error, failed to deserialize (or missing) "
                       << "required " << field_name << " in input JSON."
                       << std::endl;
         return default_choice;
@@ -278,13 +278,13 @@ T deserialize_enum(const Json::Value &value, std::string field_name,
     // if no match was found
     if (output)
     {
-        std::cout << "Error, incorrect (or no) " << field_name
+        std::cerr << "Error, incorrect (or no) " << field_name
                   << " specified in input JSON. Accepted inputs are: "
                   << '\"' << choices[0].first << '\"';
         for (std::size_t i = 1; i < choices.size(); ++i)
-            std::cout << ", \"" << choices[i].first << '\"';
+            std::cerr << ", \"" << choices[i].first << '\"';
 
-        std::cout << std::endl;
+        std::cerr << std::endl;
     }
     return default_choice;
 }

--- a/src/common/minimize/acgsd.cpp
+++ b/src/common/minimize/acgsd.cpp
@@ -149,7 +149,7 @@ std::vector<double> minimize::acgsd(diff_fn_t objective_fn,
         {
             if (settings.output_level > 0)
             {
-                cout << "Error, non-finite alpha." << endl;
+                cerr << "Error, non-finite alpha." << endl;
                 output_info();
             }
 

--- a/src/common/neighbor/cell_array_t.cpp
+++ b/src/common/neighbor/cell_array_t.cpp
@@ -262,12 +262,12 @@ void cell_array_t::get_indices(const vector<double> &lattice_positions, vector<i
 
         if (indices[i] < -1 || indices[i] > n_cells)
         {
-            cout << i << ": out of bounds index: " << indices[i] << endl;
+            cerr << i << ": out of bounds index: " << indices[i] << endl;
             for (int j = 0; j < 3; ++j)
             {
-                cout << "(" << range[j] << ", " << low_bound[j] << ") ";
+                cerr << "(" << range[j] << ", " << low_bound[j] << ") ";
             }
-            cout << endl;
+            cerr << endl;
         }
     }
 }

--- a/src/common/neighbor/utility_functions.cpp
+++ b/src/common/neighbor/utility_functions.cpp
@@ -21,7 +21,7 @@ void fbc::array_rot(const int axis, double *input,
                       {0, 0, ct}};
 
     if (axis > 2 || axis < 0)
-        cout << "Error, invalid axis (" << axis << ") passed to array_rot."
+        cerr << "Error, invalid axis (" << axis << ") passed to array_rot."
              << endl;
 
     R[(axis + 1) % 3][(axis + 2) % 3] = -st;
@@ -103,7 +103,7 @@ void fbc::invert_3x3(const double input[3][3], double inverse[3][3])
 
     if (det == 0)
     {
-        cout << "Error, matrix passed to invert_3x3 is singular."
+        cerr << "Error, matrix passed to invert_3x3 is singular."
              << endl;
     }
     else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@ int run_normal(string config_filename, MPI_Comm comm)
     Json::Value config;
     if (!io::read_json_file(config, config_filename))
     {
-        cout << "Failed to load json configuration file, run with the flag "
+        cerr << "Failed to load json configuration file, run with the flag "
              << "--generate-defaults to generate a default configuration file "
              << "with the name 'config.json' in the current directory."
              << endl;
@@ -79,8 +79,8 @@ int run_normal(string config_filename, MPI_Comm comm)
     run_settings_t settings;
     if (!settings.deserialize(config))
     {
-        std::cout << "Failed to deserialize json configuration file \""
-                  << config_filename << "\"" << std::endl;
+        cerr << "Failed to deserialize json configuration file \""
+             << config_filename << "\"" << endl;
         return EXIT_FAILURE;
     }
 

--- a/src/run/run_phonopy.cpp
+++ b/src/run/run_phonopy.cpp
@@ -155,7 +155,7 @@ int sp2::run_phonopy(const run_settings_t &settings_in, MPI_Comm)
         write_log(settings.log_filename, "Generating Displacements");
         if (generate_displacements(settings.phonopy_settings) != 0)
         {
-            std::cout << "Failed to generate displacements using phonopy."
+            std::cerr << "Failed to generate displacements using phonopy."
                       << std::endl;
             return EXIT_FAILURE;
         }
@@ -201,7 +201,7 @@ int sp2::run_phonopy(const run_settings_t &settings_in, MPI_Comm)
     if (settings.phonopy_settings.calc_bands &&
         generate_bands(settings.phonopy_settings) != 0)
     {
-        std::cout << "Failed to generate phonon band structure using phonopy."
+        std::cerr << "Failed to generate phonon band structure using phonopy."
                   << std::endl;
         return EXIT_FAILURE;
     }
@@ -437,7 +437,7 @@ vector<pair<double, vector<vec3_t>>> read_eigs()
     ifstream infile("band.yaml");
     if (!infile)
     {
-        cout << "Error opening band.yaml" << endl;
+        cerr << "Error opening band.yaml" << endl;
         return {};
     }
 

--- a/src/run/run_relaxation.cpp
+++ b/src/run/run_relaxation.cpp
@@ -8,7 +8,7 @@ int sp2::run_relaxation(const run_settings_t &config, MPI_Comm)
 {
     if (config.relaxation_settings.output_file.empty())
     {
-        std::cout << "No output file name given for structural relaxation."
+        std::cerr << "No output file name given for structural relaxation."
                   << std::endl;
 
         return EXIT_FAILURE;

--- a/src/run/run_settings_t.cpp
+++ b/src/run/run_settings_t.cpp
@@ -17,7 +17,7 @@ bool load_structure(const Json::Value &config, structure_t &structure)
     {
         if (!io::read_structure(structure_file, structure))
         {
-            cout << "Error, failed to read structure file." << endl;
+            cerr << "Error, failed to read structure file." << endl;
             return false;
         }
     }
@@ -97,4 +97,3 @@ bool run_settings_t::deserialize(const Json::Value &input)
 
     return true;
 }
-

--- a/src/symm/space_group_t.cpp
+++ b/src/symm/space_group_t.cpp
@@ -183,7 +183,7 @@ symm::read_groups(std::string filename)
     ifstream infile(filename);
     if (!infile.is_open())
     {
-        cout << "Failed to open space group input file \""
+        cerr << "Failed to open space group input file \""
              << filename << "\"." << endl;
         return groups;
     }


### PR DESCRIPTION
these are the less controversial things I'd move to stderr;
clear, definitive errors, especially those printed shortly before an abort.

(personally speaking, I'd go even further and move all of the debug output from e.g. the minimizers there, but that's mostly because I'm a fanatic who regards stdout as a holy ground for main())